### PR TITLE
don’t break when Petfinder API returns an array of options or breeds

### DIFF
--- a/spec/pet_fetcher_spec.rb
+++ b/spec/pet_fetcher_spec.rb
@@ -44,4 +44,40 @@ describe 'PetFetcher' do
     stub_request(:get, /^http\:\/\/www\.petharbor\.com\/petoftheday\.asp/).to_return(:status => 500)
     lambda { PetFetcher.get_petharbor_pet }.must_raise RuntimeError
   end
+
+  describe 'get_petfinder_option' do
+    it 'uses friendly values' do
+      PetFetcher.send(:get_petfinder_option, {"option" => {"$t" => "housebroken"}}).must_equal 'house trained'
+      PetFetcher.send(:get_petfinder_option, {"option" => {"$t" => "housetrained"}}).must_equal 'house trained'
+      PetFetcher.send(:get_petfinder_option, {"option" => {"$t" => "noClaws"}}).must_equal 'declawed'
+      PetFetcher.send(:get_petfinder_option, {"option" => {"$t" => "altered"}}).must_equal 'altered'
+    end
+
+    it 'handles multiple values in the options hash' do
+      PetFetcher.send(:get_petfinder_option,
+                      {"option" => [{"$t" => "hasShots"},
+                                    {"$t" => "noClaws"}]}).must_equal 'declawed'
+    end
+
+    it 'ignores some possible values' do
+      PetFetcher.send(:get_petfinder_option,
+                      {"option" => [{"$t" => "hasShots"},
+                                    {"$t" => "noCats"},
+                                    {"$t" => "noDogs"},
+                                    {"$t" => "noKids"},
+                                    {"$t" => "totally not in the xsd"},
+                      ]}).must_equal nil
+
+    end
+  end
+
+  describe 'get_petfinder_breed' do
+    it 'works with a single hash' do
+      PetFetcher.send(:get_petfinder_breed, {"breed" => {"$t" => "Spaniel"}}).must_equal 'Spaniel'
+    end
+
+    it 'works with an array of hashes' do
+      PetFetcher.send(:get_petfinder_breed, {"breed" => [{"$t" => "Spaniel"}, {"$t" => "Pomeranian"}]}).must_equal 'Spaniel/Pomeranian mix'
+    end
+  end
 end


### PR DESCRIPTION
The Petfinder API returns `option` and `breed` as arrays when there is more than one. This causes `rake tweet_pet` to error every few requests:

``` bash
# works
rake tweet_pet
{"option"=>{"$t"=>"hasShots"}}

# doesn't work
rake tweet_pet
{"option"=>[{"$t"=>"hasShots"}, {"$t"=>"noClaws"}, {"$t"=>"altered"}, {"$t"=>"housetrained"}]}
rake aborted!
TypeError: no implicit conversion of String into Integer
/Users/bortega/projects/github/CutePets/lib/cute_pets/pet_fetcher.rb:85:in `[]'
/Users/bortega/projects/github/CutePets/lib/cute_pets/pet_fetcher.rb:85:in `get_petfinder_option'
/Users/bortega/projects/github/CutePets/lib/cute_pets/pet_fetcher.rb:30:in `get_petfinder_pet'
/Users/bortega/projects/github/CutePets/lib/cute_pets.rb:12:in `post_pet'
/Users/bortega/projects/github/CutePets/Rakefile:10:in `block in <top (required)>'
Tasks: TOP => tweet_pet
(See full trace by running task with --trace)
```

This PR handles those cases and formats multiple options in a more readable way.
