### PR TITLE
Remove redundant msp link

### DIFF
--- a/where.geojson
+++ b/where.geojson
@@ -19,18 +19,6 @@
 			"type": "Feature", 
 			"properties": 
 			{ 
-				"twitter" : "http://twitter.com/CutePetsMSP"
-			}, 
-			"geometry": 
-			{ 
-				"type": "Point", 
-				"coordinates": [ -93.1721599, 44.9754171 ] 
-			} 
-		},
-		{ 
-			"type": "Feature", 
-			"properties": 
-			{ 
 				"twitter" : "http://twitter.com/CutePetsCHA"
 			}, 
 			"geometry": 


### PR DESCRIPTION
Keep the coordinates chosen by the MSP people