### PR TITLE
Add history tracking so we don't tweet the same pets multiple times.

### DIFF
--- a/.env
+++ b/.env
@@ -22,3 +22,8 @@ petharbor_shelter_id='DNVR'
 # This must be all or a smaller set of these pet types.
 # The types must be separated by a space.
 petharbor_pet_types='cat dog others'
+
+# file to store history so we don't tweet the same pets many times
+history_file='~/.cutepets_history'
+# number of tries to find a new pet before we give up
+number_tries='10'

--- a/lib/cute_pets.rb
+++ b/lib/cute_pets.rb
@@ -16,9 +16,9 @@ module CutePets
 
   def get_history
     history_filepath = File.expand_path(ENV.fetch("history_file"))
-    history = File.file?(history_filepath) ? File.readlines(history_filepath) : []
+    File.file?(history_filepath) ? File.readlines(history_filepath) : []
   end
-  
+
   def append_history(text)
     history_filepath = File.expand_path(ENV.fetch("history_file"))
     File.open(history_filepath, "a") do |f|

--- a/lib/cute_pets.rb
+++ b/lib/cute_pets.rb
@@ -6,14 +6,40 @@ Dotenv.load
 module CutePets
   extend self
 
-  def post_pet()
-    pet = nil
-    if ENV.fetch('pet_datasource').downcase == 'petfinder'
-      pet = PetFetcher.get_petfinder_pet
+  def fetch_pet
+    if ENV.fetch("pet_datasource").downcase == "petfinder"
+      PetFetcher.get_petfinder_pet
     else
-      pet = PetFetcher.get_petharbor_pet
+      PetFetcher.get_petharbor_pet
     end
+  end
+
+  def post_pet
+    pet = nil
+    pet = fetch_pet
+    # Check that we haven't tweeted this pet before.
+    history_file = ENV.fetch("history_file")
+    history_filepath = File.expand_path(history_file)
+    if File.file?(history_filepath)
+      num_tries = ENV.fetch("number_tries").to_i
+      history = File.readlines(history_filepath)
+      num_tries.times do
+        new_pet = true
+        history.each do |url|
+          if url.strip == pet[:link]
+            new_pet = false
+            break
+          end
+        end
+        break if new_pet
+        pet = fetch_pet
+      end
+    end
+
     if pet
+      File.open(history_filepath, "a") do |f|
+        f.puts pet[:link]
+      end
       message = TweetGenerator.create_message(pet[:name], pet[:description], pet[:link])
       TweetGenerator.tweet(message, pet[:pic])
     end

--- a/lib/cute_pets.rb
+++ b/lib/cute_pets.rb
@@ -14,32 +14,31 @@ module CutePets
     end
   end
 
+  def get_history
+    history_filepath = File.expand_path(ENV.fetch("history_file"))
+    history = File.file?(history_filepath) ? File.readlines(history_filepath) : []
+  end
+  
+  def append_history(text)
+    history_filepath = File.expand_path(ENV.fetch("history_file"))
+    File.open(history_filepath, "a") do |f|
+      f.puts text
+    end
+  end
+
   def post_pet
     pet = nil
     pet = fetch_pet
-    # Check that we haven't tweeted this pet before.
-    history_file = ENV.fetch("history_file")
-    history_filepath = File.expand_path(history_file)
-    if File.file?(history_filepath)
-      num_tries = ENV.fetch("number_tries").to_i
-      history = File.readlines(history_filepath)
-      num_tries.times do
-        new_pet = true
-        history.each do |url|
-          if url.strip == pet[:link]
-            new_pet = false
-            break
-          end
-        end
-        break if new_pet
-        pet = fetch_pet
-      end
+    num_tries = ENV.fetch("number_tries").to_i
+    history = get_history
+    # Try a few times to find one we haven't tweeted before.
+    num_tries.times do
+      break unless history.include?(pet[:link] + "\n")
+      pet = fetch_pet
     end
 
     if pet
-      File.open(history_filepath, "a") do |f|
-        f.puts pet[:link]
-      end
+      append_history(pet[:link])
       message = TweetGenerator.create_message(pet[:name], pet[:description], pet[:link])
       TweetGenerator.tweet(message, pet[:pic])
     end


### PR DESCRIPTION
My CutePets accounts were tweeting the same pets over and over again, so I added this feature to prevent that. Let me know if it needs any more polishing.

If you have [t](https://github.com/sferik/t) set up, you can use the following bash one-liner to get all the previously tweeted URLs and add them to your history file (of course change the Twitter handle)
```
t timeline -n 1000 CutePetsBham | awk '{if (NF > 2) {print $(NF-1)}}' | xargs -I + curl -s -o /dev/null -I -w "%{redirect_url}\n" + | sort | uniq > ~/.cutepets_history
```