### PR TITLE
Issue 58: Bump ruby version to 2.4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
 rvm:
-  - ruby-2.1.2
+  - ruby-2.4.2
 notifications:
   webhooks: http://project-monitor.codeforamerica.org/projects/d702edae-5a33-478b-9d08-acc4a7826533/status

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.1.2'
+ruby '2.4.2'
 
 gem 'twitter'
 gem 'dotenv'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,10 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.3.6)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     buftok (0.2.0)
-    crack (0.4.2)
+    crack (0.4.3)
       safe_yaml (~> 1.0.0)
     dotenv (0.11.1)
       dotenv-deployment (~> 0.0.2)
@@ -11,18 +12,20 @@ GEM
     equalizer (0.0.9)
     faraday (0.9.0)
       multipart-post (>= 1.2, < 3)
+    hashdiff (0.3.6)
     hpricot (0.8.6)
     http (0.6.2)
       http_parser.rb (~> 0.6.0)
     http_parser.rb (0.6.0)
-    json (1.8.1)
+    json (1.8.6)
     memoizable (0.4.2)
       thread_safe (~> 0.3, >= 0.3.1)
     minitest (5.4.1)
     multipart-post (2.0.0)
     naught (1.0.0)
+    public_suffix (3.0.0)
     rake (10.3.2)
-    safe_yaml (1.0.3)
+    safe_yaml (1.0.4)
     simple_oauth (0.2.0)
     thread_safe (0.3.4)
     twitter (5.11.0)
@@ -37,9 +40,10 @@ GEM
       naught (~> 1.0)
       simple_oauth (~> 0.2.0)
     vcr (2.9.3)
-    webmock (1.18.0)
+    webmock (3.0.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
+      hashdiff
 
 PLATFORMS
   ruby
@@ -52,3 +56,9 @@ DEPENDENCIES
   twitter
   vcr
   webmock
+
+RUBY VERSION
+   ruby 2.4.2p198
+
+BUNDLED WITH
+   1.15.4

--- a/spec/fixtures/vcr_cassettes/petharbor.yml
+++ b/spec/fixtures/vcr_cassettes/petharbor.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://www.petharbor.com/petoftheday.asp?availableonly=1&shelterlist='DNVR'&showstat=1&source=results&type=dog
+    uri: http://www.petharbor.com/petoftheday.asp?availableonly=1&shelterlist=%27DNVR%27&showstat=1&source=results&type=dog
     body:
       encoding: US-ASCII
       string: ''
@@ -48,6 +48,6 @@ http_interactions:
         align=center><B><FONT color=\"black\" face=\"arial\" size=\"10\">NEUTERED
         MALE WHITE BICHON FRISE</FONT></B></TD></TR><TR><TD align=center><B><FONT
         color=\"black\" face=\"arial\" size=\"10\">Denver Animal Shelter</FONT></B></TD></TR></TABLE>"); '
-    http_version: 
+    http_version:
   recorded_at: Mon, 15 Sep 2014 18:49:28 GMT
 recorded_with: VCR 2.9.3


### PR DESCRIPTION
Closes #58. 2.4.2 is the latest version of ruby [supported by Heroku](https://devcenter.heroku.com/articles/ruby-support#supported-runtimes). The current version is causing deploys of this app to Heroku to fail.

This also updates various dependencies in the lockfile using `bundle update #{name}` because of issues related to newer versions of ruby.

- `json` [⚠](https://github.com/flori/json/issues/286)
- `safe_yaml` [⚠](https://github.com/dtao/safe_yaml/issues/67)
- `webmock` [⚠](https://github.com/bblimke/webmock/issues/683)

For folks that have this checked out locally, I also had to `brew install --force` to force an up-to-date build of `http_parse.rb`, which was throwing `Symbol not found: _rb_cFixnum`.

Finally, this updates the petharbor cassette URI to include URL encoded single quotes, which were causing a failing test. The change in encoding was probably just an internal change to `URI.encode_www_form` from ruby 2.1 to 2.4.