### PR TITLE
Git ignore rbenv local version file and bundle directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .DS_Store
+.bundle/
+.ruby-version


### PR DESCRIPTION
Just a little change to `.gitignore` some extra devtool artifacts.  `.ruby-version` is a file that pins the ruby version when you run `rbenv local X.Y.Z`, and bundle sometimes copies config locally to a `.bundle` directory.